### PR TITLE
titleresolver now calls youtube-dl asyncronously

### DIFF
--- a/titleresolver.lua
+++ b/titleresolver.lua
@@ -3,17 +3,33 @@ local msg = require("mp.msg")
 -- resolve url title and send it back to playlistmanager
 mp.register_script_message("resolveurltitle", function(filename)
   local args = { 'youtube-dl', '--no-playlist', '--flat-playlist', '-sJ', filename }
-  local res = utils.subprocess({ args = args, cancellable = false })
-  if res.status == 0 then
-    local json, err = utils.parse_json(res.stdout)
-    if not err then
-      local is_playlist = json['_type'] and json['_type'] == 'playlist'
-      local title = (is_playlist and '[playlist]: ' or '') .. json['title']
-      mp.commandv('script-message', 'playlistmanager', 'addurl', filename, title)
-    else
-      msg.error("Failed parsing json, reason: "..(err or "unknown"))
+  local req = mp.command_native_async({
+                name = "subprocess",
+                args = args,
+                playback_only = false,
+                capture_stdout = true
+  }, function (success, res)
+    if res.killed_by_us then
+      msg.verbose('request to resolve url title ' .. filename .. ' timed out')
+      return
     end
-  else
-    msg.error("Failed to resolve url title "..filename.." Error: "..(res.error or "unknown"))
+
+    if res.status == 0 then
+      local json, err = utils.parse_json(res.stdout)
+      if not err then
+        local is_playlist = json['_type'] and json['_type'] == 'playlist'
+        local title = (is_playlist and '[playlist]: ' or '') .. json['title']
+        mp.commandv('script-message', 'playlistmanager', 'addurl', filename, title)
+      else
+        msg.error("Failed parsing json, reason: "..(err or "unknown"))
+      end
+    else
+      msg.error("Failed to resolve url title "..filename.." Error: "..(res.error or "unknown"))
+    end
   end
+  )
+
+  mp.add_timeout(5, function()
+    mp.abort_async_command(req)
+  end)
 end)


### PR DESCRIPTION
Allows for a timeout on the title resolve request.

What often seemed to be occurring before was that when playing certain
playlists, for example youtube radios, the request to youtube-dl would
never return until the subprocess was forcibly closed when mpv exited.

This created a noticeable delay when closing the player, and it is probably
not ideal to have 200+ processing running in the background for the
entirety of playback. Running it asynchronously allows the script to terminate
the request after an arbitrary amount of time has passed.