### PR TITLE
script opts can now be updated during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Default visual cues:
 It will make sense once you try the script!
 
 ## Settings
-You can modify behaviour of the script in the settings variable in the lua file or a `playlistmanager.conf` lua-setting file. The configuration file should be placed in `script-opts` directory, not in `scripts`. Note: the conf file will override any
-changed setting in the lua file. There is a playlistmanager.conf file in this repo with the default values of the script. You can also pass settings from the command line on startup such as `mpv --idle=once --script-opts=playlistmanager-loadfiles_on_start=yes`.
+You can modify behaviour of the script in the settings variable in the lua file or a `playlistmanager.conf` lua-setting file in`script-opts` directory. 
+Note: the conf file will override any changed setting in the lua file. There is a playlistmanager.conf file in this repo with the default values of the script. 
+You can pass settings from the command line on startup such as `mpv --idle=once --script-opts=playlistmanager-loadfiles_on_start=yes`. 
+You can also change settings during runtime with a keybind or command like `KEY change-list script-opts append playlistmanager-showamount=10`.
 
 #### Url title resolving
 If you want playlistmanager to fetch and display titles of all playlist urls(mpv defaults to current file only) you will need to use `resolve_titles = yes`(default is no) setting. Title resolving requires `youtube-dl` to be in PATH to work.

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -212,6 +212,7 @@ function update_opts(changelog)
   if changelog.loadfiles_filetypes then
     settings.loadfiles_filetypes = utils.parse_json(settings.loadfiles_filetypes)
 
+    filetype_lookup = {}
     --create loadfiles set
     for _, ext in ipairs(settings.loadfiles_filetypes) do
       filetype_lookup[ext] = true

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -161,27 +161,12 @@ local settings = {
 
 }
 local opts = require("mp.options")
-opts.read_options(settings, "playlistmanager")
+opts.read_options(settings, "playlistmanager", function(list) update_opts(list) end)
 
 local utils = require("mp.utils")
 local msg = require("mp.msg")
 local assdraw = require("mp.assdraw")
 
---parse filename json
-if(settings.filename_replace~="") then
-  settings.filename_replace = utils.parse_json(settings.filename_replace)
-else
-  settings.filename_replace = false
-end
-
---parse loadfiles json
-settings.loadfiles_filetypes = utils.parse_json(settings.loadfiles_filetypes)
-
---create loadfiles set
-local filetype_lookup = {}
-for _, ext in ipairs(settings.loadfiles_filetypes) do
-  filetype_lookup[ext] = true
-end
 
 --check os
 if settings.system=="auto" then
@@ -208,6 +193,44 @@ local url_table = {}
 local requested_urls = {}
 --state for if we sort on playlist size change
 local sort_watching = false
+
+local filetype_lookup = {}
+
+function update_opts(changelog)
+  msg.verbose('updating options')
+
+  --parse filename json
+  if changelog.filename_replace then
+    if(settings.filename_replace~="") then
+      settings.filename_replace = utils.parse_json(settings.filename_replace)
+    else
+      settings.filename_replace = false
+    end
+  end
+
+  --parse loadfiles json
+  if changelog.loadfiles_filetypes then
+    settings.loadfiles_filetypes = utils.parse_json(settings.loadfiles_filetypes)
+
+    --create loadfiles set
+    for _, ext in ipairs(settings.loadfiles_filetypes) do
+      filetype_lookup[ext] = true
+    end
+  end
+
+  if changelog.resolve_titles then
+    resolve_titles()
+  end
+
+  if changelog.playlist_display_timeout then
+    keybindstimer = mp.add_periodic_timer(settings.playlist_display_timeout, remove_keybinds)
+    keybindstimer:kill()
+  end
+
+  if playlist_visible then showplaylist() end
+end
+
+update_opts({filename_replace = true, loadfiles_filetypes = true})
 
 function on_loaded()
   filename = mp.get_property("filename")
@@ -859,8 +882,14 @@ end
 
 mp.observe_property('playlist-count', "number", function()
   if playlist_visible then showplaylist() end
-  if settings.prefer_titles == 'none' or not settings.resolve_titles then return end
-  -- code to resolve url titles
+  if settings.prefer_titles == 'none' then return end
+  -- resolve titles
+  resolve_titles()
+end)
+
+--resolves url titles by calling youtube-dl
+function resolve_titles()
+  if not settings.resolve_titles then return end
   local length = mp.get_property_number('playlist-count', 0)
   if length < 2 then return end
   local i=0
@@ -914,7 +943,7 @@ mp.observe_property('playlist-count', "number", function()
     end
     i=i+1
   end
-end)
+end
 
 --script message handler
 function handlemessage(msg, value, value2)


### PR DESCRIPTION
Uses the mp.options helper function to update script options
during runtime. This allows for options like display duration, title resolution,
etc, to be changed with profiles/keybinds/console commands.

I've moved some of the code into the update function so they
should be updated properly if the option changes.

This isn't like my other two pull requests, if you want to pull this
you'll want to check how all your different options would handle
being updated. I've tried to account for the obvious options, but
I don't know this code well enough to know where to look for
unexpected behaviour.

If you find some aspect of the code can't be easily changed to do
this then I won't be offended if you reject the pull request.