### PR TITLE
make navigation keys work

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ If you want playlistmanager to fetch and display titles of all playlist urls(mpv
   - Moves the cursor up in playlist, if at first entry loops to end of playlist.
 - __movedown__(DOWN)
   - Moves the cursor down in playlist, if at last entry loops to start of playlist.
+- __movepageup__ (Page Up)
+  - Moves the cursor one page up in the playlist, or to the first entry. 
+- __movepagedown__ (Page Down)
+  - Moves the cursor one page down in the playlist, or to the last entry. 
+- __movebegin__ (Home)
+  - Moves the cursor to the first entry in the playlist.
+- __moveend__ (End)
+  - Moves the cursor to the last entry in the playlist.
 - __removefile__(Backspace)
   - Removes the file currently selected with the cursor from the playlist
 - __playfile__(Enter)

--- a/playlistmanager.conf
+++ b/playlistmanager.conf
@@ -10,6 +10,10 @@ dynamic_binds=yes
 #to bind multiple keys separate them by a space
 key_moveup=UP
 key_movedown=DOWN
+key_movepageup=PGUP
+key_movepagedown=PGDWN
+key_movebegin=HOME
+key_moveend=END
 key_selectfile=RIGHT LEFT
 key_unselectfile=
 key_playfile=ENTER

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -9,6 +9,10 @@ local settings = {
   -- to bind multiple keys separate them by a space
   key_moveup = "UP",
   key_movedown = "DOWN",
+  key_movepageup = "PGUP",
+  key_movepagedown = "PGDWN",
+  key_movebegin = "HOME",
+  key_moveend = "END",
   key_selectfile = "RIGHT LEFT",
   key_unselectfile = "",
   key_playfile = "ENTER",
@@ -532,6 +536,44 @@ function movedown()
   showplaylist()
 end
 
+function movepageup()
+  refresh_globals()
+  if plen == 0 or cursor == 0 then return end
+  local prev_cursor = cursor
+  cursor = cursor - settings.showamount
+  if cursor < 0 then cursor = 0 end
+  if selection then mp.commandv("playlist-move", prev_cursor, cursor) end
+  showplaylist()
+end
+
+function movepagedown()
+  refresh_globals()
+  if plen == 0 or cursor == plen-1 then return end
+  local prev_cursor = cursor
+  cursor = cursor + settings.showamount
+  if cursor >= plen then cursor = plen-1 end
+  if selection then mp.commandv("playlist-move", prev_cursor, cursor+1) end
+  showplaylist()
+end
+
+function movebegin()
+  refresh_globals()
+  if plen == 0 or cursor == 0 then return end
+  local prev_cursor = cursor
+  cursor = 0
+  if selection then mp.commandv("playlist-move", prev_cursor, cursor) end
+  showplaylist()
+end
+
+function moveend()
+  refresh_globals()
+  if plen == 0 or cursor == plen-1 then return end
+  local prev_cursor = cursor
+  cursor = plen-1
+  if selection then mp.commandv("playlist-move", prev_cursor, cursor+1) end
+  showplaylist()
+end
+
 function write_watch_later(force_write)
   if mp.get_property_bool("save-position-on-quit") or force_write then
     mp.command("write-watch-later-config")
@@ -841,6 +883,10 @@ end
 function add_keybinds()
   bind_keys(settings.key_moveup, 'moveup', moveup, "repeatable")
   bind_keys(settings.key_movedown, 'movedown', movedown, "repeatable")
+  bind_keys(settings.key_movepageup, 'movepageup', movepageup, "repeatable")
+  bind_keys(settings.key_movepagedown, 'movepagedown', movepagedown, "repeatable")
+  bind_keys(settings.key_movebegin, 'movebegin', movebegin, "repeatable")
+  bind_keys(settings.key_moveend, 'moveend', moveend, "repeatable")
   bind_keys(settings.key_selectfile, 'selectfile', selectfile)
   bind_keys(settings.key_unselectfile, 'unselectfile', unselectfile)
   bind_keys(settings.key_playfile, 'playfile', playfile)
@@ -857,6 +903,10 @@ function remove_keybinds()
   if settings.dynamic_binds then
     unbind_keys(settings.key_moveup, 'moveup')
     unbind_keys(settings.key_movedown, 'movedown')
+    unbind_keys(settings.key_movepageup, 'movepageup')
+    unbind_keys(settings.key_movepagedown, 'movepagedown')
+    unbind_keys(settings.key_movebegin, 'movebegin')
+    unbind_keys(settings.key_moveend, 'moveend')
     unbind_keys(settings.key_selectfile, 'selectfile')
     unbind_keys(settings.key_unselectfile, 'unselectfile')
     unbind_keys(settings.key_playfile, 'playfile')


### PR DESCRIPTION
Page Up and Page Down now moves one page (showamount option) up or down, Home and End also jumps to the beginning/end of the playlist. This makes it easier to navigate very large playlists.