### PR TITLE
Resolve local titles

### DIFF
--- a/playlistmanager.conf
+++ b/playlistmanager.conf
@@ -82,7 +82,12 @@ youtube_dl_executable=youtube-dl
 prefer_titles=url
 
 #call youtube-dl to resolve the titles of urls in the playlist
-resolve_titles=no
+#if yes, prefer_titles must be set to "url" or "all" for this to work
+resolve_url_titles=no
+
+#call ffprobe to resolve the titles of local files in the playlist (if they exist in the metadata)
+#if yes, prefer_titles must be set to "all" for this to work
+resolve_local_titles=no
 
 #timeout in seconds for title resolving
 resolve_title_timeout=15


### PR DESCRIPTION
Looks neater now. I also clarified usage of the conf options.

The only problem I'm encountering is mpv stuttering ever so briefly when 10+ local files are loaded at the same. Very minor issue but is there a way to slow down or segment the `resolve_local_titles` function?