### PR TITLE
fix script-message’s param type error

### DIFF
--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -693,7 +693,7 @@ function showplaylist(duration)
   draw_playlist()
   keybindstimer:kill()
 
-  local dur = tonumber(duration or settings.playlist_display_timeout)
+  local dur = tonumber(duration) or settings.playlist_display_timeout
   if dur > 0 then
     keybindstimer = mp.add_periodic_timer(dur, remove_keybinds)
   end
@@ -709,7 +709,7 @@ function showplaylist_non_interactive(duration)
   draw_playlist()
   keybindstimer:kill()
 
-  local dur = tonumber(duration or settings.playlist_display_timeout)
+  local dur = tonumber(duration) or settings.playlist_display_timeout
   if dur > 0 then
     keybindstimer = mp.add_periodic_timer(dur, remove_keybinds)
   end

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -693,7 +693,7 @@ function showplaylist(duration)
   draw_playlist()
   keybindstimer:kill()
 
-  local dur = duration or settings.playlist_display_timeout
+  local dur = tonumber(duration or settings.playlist_display_timeout)
   if dur > 0 then
     keybindstimer = mp.add_periodic_timer(dur, remove_keybinds)
   end
@@ -709,7 +709,7 @@ function showplaylist_non_interactive(duration)
   draw_playlist()
   keybindstimer:kill()
 
-  local dur = duration or settings.playlist_display_timeout
+  local dur = tonumber(duration or settings.playlist_display_timeout)
   if dur > 0 then
     keybindstimer = mp.add_periodic_timer(dur, remove_keybinds)
   end


### PR DESCRIPTION
use `script-message` to show playlist with duration
`KEY script-message playlistmanager show playlist 1`
`KEY script-message playlistmanager show playlist-nokeys 1`

![屏幕截图 2023-08-04 092842](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/833eaea1-57dd-480b-b4b5-bf98eb104b64)

need to cast string to number

