### PR TITLE
Use the sorting function `StrCmpLogicalW` provided by the win32 API

### DIFF
--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -294,11 +294,51 @@ end
 
 update_opts({filename_replace = true, loadfiles_filetypes = true})
 
+----- winapi start -----
+-- in windows system, we can use the sorting function provided by the win32 API
+-- see https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-strcmplogicalw
+local winapisort = nil
+if settings.system == "windows" then
+  -- ffiok is false usually means the mpv builds without luajit
+  local ffiok, ffi = pcall(require, "ffi")
+  if ffiok then
+    ffi.cdef[[
+      int MultiByteToWideChar(unsigned int CodePage, unsigned long dwFlags, const char *lpMultiByteStr, int cbMultiByte, wchar_t *lpWideCharStr, int cchWideChar);
+      int StrCmpLogicalW(const wchar_t * psz1, const wchar_t * psz2);        
+    ]]
+   
+    local shlwapi = ffi.load("shlwapi.dll")
+    
+    function MultiByteToWideChar(MultiByteStr)
+      local UTF8_CODEPAGE = 65001
+      if MultiByteStr then
+        local utf16_len = ffi.C.MultiByteToWideChar(UTF8_CODEPAGE, 0, MultiByteStr, -1, nil, 0)
+        if utf16_len > 0 then
+          local utf16_str = ffi.new("wchar_t[?]", utf16_len)
+          if ffi.C.MultiByteToWideChar(UTF8_CODEPAGE, 0, MultiByteStr, -1, utf16_str, utf16_len) > 0 then
+            return utf16_str
+          end
+        end
+      end
+      return ""
+    end
+    
+    winapisort = function (a, b)
+      return shlwapi.StrCmpLogicalW(MultiByteToWideChar(a), MultiByteToWideChar(b)) < 0
+    end
+    
+  end
+end
+----- winapi end -----
+
 local sort_modes = {
   {
     id="name-asc",
     title="name ascending",
     sort_fn=function (a, b, playlist)
+      if winapisort ~= nil then 
+        return winapisort(playlist[a].string, playlist[b].string)
+      end
       return alphanumsort(playlist[a].string, playlist[b].string)
     end,
   },
@@ -306,6 +346,9 @@ local sort_modes = {
     id="name-desc",
     title="name descending",
     sort_fn=function (a, b, playlist)
+      if winapisort ~= nil then 
+        return winapisort(playlist[b].string, playlist[a].string)
+      end
       return alphanumsort(playlist[b].string, playlist[a].string)
     end,
   },
@@ -903,8 +946,13 @@ function playlist(force_dir)
   if force_dir then dir = force_dir end
 
   local files = file_filter(utils.readdir(dir, "files"))
-  table.sort(files, alphanumsort)
-
+  if winapisort ~= nil then
+    table.sort(files, winapisort)
+  else
+    table.sort(files, alphanumsort)
+  end
+  
+  
   if files == nil then
     msg.verbose("no files in directory")
     return


### PR DESCRIPTION
The current sorting function `alphanumsort()` is very different from the sorting in Windows Explorer.
For Example: 
- In Windows Explorer
![windows explorer](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/050ea8df-2d7b-473d-b48f-4d4a4949c6fe)
- In playlistmanager
![before](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/7b874958-50dc-4216-8891-b0eec91f23ac)

Microsoft does not open source the sorting algorithm, but does provide the API, see [StrCmpLogicalW](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-strcmplogicalw).

Fortunately, [LuaJIT ](https://luajit.org/) can call Windows API, and most popular mpv windows build are builds with LuaJIT, such as  [shinchiro/mpv-winbuild-cmake](https://github.com/shinchiro/mpv-winbuild-cmake). 

So if OS is Windows and mpv builds with luaJIT, we can use the win32 API to ensure that the sorting in playlistmanager  is exactly the same as Windows Explorer, \
otherwise, use the default sorting function `alphanumsort()`.

- In playlistmanager after using `StrCmpLogicalW` sort
![after](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/8a3e7628-4735-4296-81d0-8cf7883b66b8)




