### PR TITLE
auto calculate showamount, fix #106

### DIFF
--- a/playlistmanager.conf
+++ b/playlistmanager.conf
@@ -116,6 +116,7 @@ playlist_display_timeout=0
 peek_respect_display_timeout=no
 
 #the maximum amount of lines playlist will render. Optimal value depends on font/video size etc.
+#special value 'auto' means auto calculate it
 showamount=9
 
 #font size scales by window, if no then needs larger font and padding sizes

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -596,7 +596,7 @@ function parse_header(string)
   local esc_title = stripfilename(mp.get_property("media-title"), true):gsub("%%", "%%%%")
   local esc_file = stripfilename(mp.get_property("filename")):gsub("%%", "%%%%")
   return string:gsub("%%N", "\\N")
-               -- add an blank character to ensure that the height of the empty line is the same as the non empty line
+               -- add a blank character at the end of each '\N'  to ensure that the height of the empty line is the same as the non empty line
                :gsub("\\N", "\\N ")
                :gsub("%%pos", mp.get_property_number("playlist-pos",0)+1)
                :gsub("%%plen", mp.get_property("playlist-count"))

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -265,6 +265,13 @@ if settings.showamount=='auto' then
   -- exclude the header line
   if settings.playlist_header ~= "" then
     settings.showamount = settings.showamount - 1
+    -- probably some newlines (%N or \N) in the header
+    for _ in settings.playlist_header:gmatch('%%N') do
+      settings.showamount = settings.showamount - 1
+    end
+    for _ in settings.playlist_header:gmatch('\\N') do
+      settings.showamount = settings.showamount - 1
+    end
   end
   
   msg.info('auto showamount: ' .. settings.showamount)
@@ -589,6 +596,8 @@ function parse_header(string)
   local esc_title = stripfilename(mp.get_property("media-title"), true):gsub("%%", "%%%%")
   local esc_file = stripfilename(mp.get_property("filename")):gsub("%%", "%%%%")
   return string:gsub("%%N", "\\N")
+               -- add an blank character to ensure that the height of the empty line is the same as the non empty line
+               :gsub("\\N", "\\N ")
                :gsub("%%pos", mp.get_property_number("playlist-pos",0)+1)
                :gsub("%%plen", mp.get_property("playlist-count"))
                :gsub("%%cursor", cursor+1)

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -284,6 +284,16 @@ if settings.showamount=='auto' then
   end
   
   msg.info('auto showamount: ' .. settings.showamount)
+  
+  -- no word wrapping, let long filenames overflow to the right
+  if settings.style_ass_tags == nil or settings.style_ass_tags == '' then
+    settings.style_ass_tags = '{\\q2}'
+  else
+    -- if wrapstyle tag exists, remove it
+    settings.style_ass_tags = settings.style_ass_tags:gsub('\\q%d+','')
+    -- add to end
+    settings.style_ass_tags = settings.style_ass_tags:gsub('}', '\\q2}')
+  end
 else
   settings.showamount = tonumber(settings.showamount)
 end

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -242,6 +242,13 @@ end
 if settings.showamount=='auto' then
   -- same as draw_playlist() height
   local playlist_h = 360
+  if settings.scale_playlist_by_window then
+    -- mp.set_osd_ass(0, 0, ass.text) default res_y is 288
+    -- https://mpv.io/manual/stable/#command-interface-ass-events
+    -- https://github.com/mpv-player/mpv/blob/e22a2f04833852ce825eb7c1235d9bdaaa9b2397/sub/osd_libass.c#L111-L112
+    -- https://github.com/mpv-player/mpv/blob/e22a2f04833852ce825eb7c1235d9bdaaa9b2397/sub/ass_mp.h#L33
+    playlist_h = 288
+  end
   if mp.get_property("osd-align-x") == "left" and mp.get_property("osd-align-y") == "top" then
     -- both top and bottom with same padding
     playlist_h = playlist_h - settings.text_padding_y * 2

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -241,14 +241,16 @@ end
 -- auto calculate showamount
 if settings.showamount=='auto' then
   -- same as draw_playlist() height
-  local playlist_h = 360
+  local h = 360
   if settings.scale_playlist_by_window then
     -- mp.set_osd_ass(0, 0, ass.text) default res_y is 288
     -- https://mpv.io/manual/stable/#command-interface-ass-events
     -- https://github.com/mpv-player/mpv/blob/e22a2f04833852ce825eb7c1235d9bdaaa9b2397/sub/osd_libass.c#L111-L112
     -- https://github.com/mpv-player/mpv/blob/e22a2f04833852ce825eb7c1235d9bdaaa9b2397/sub/ass_mp.h#L33
-    playlist_h = 288
+    h = 288
   end
+  
+  local playlist_h = h
   if mp.get_property("osd-align-x") == "left" and mp.get_property("osd-align-y") == "top" then
     -- both top and bottom with same padding
     playlist_h = playlist_h - settings.text_padding_y * 2
@@ -257,8 +259,8 @@ if settings.showamount=='auto' then
   -- osd-font-size is based on 720p height
   -- see https://mpv.io/manual/stable/#options-osd-font-size 
   -- details in https://mpv.io/manual/stable/#options-sub-font-size
-  -- draw_playlist() is based on 360p height, so we need to divide by 2
-  local fs = mp.get_property_native('osd-font-size') / 2
+  -- draw_playlist() is based on 360p or 288p height, need some conversion
+  local fs = mp.get_property_native('osd-font-size') * h / 720
   -- get the ass font size
   if settings.style_ass_tags ~= nil then
     local ass_fs_tag = settings.style_ass_tags:match('\\fs%d+')


### PR DESCRIPTION
### Some test cases, only list key options
- `scale_playlist_by_window=no` `showamount=auto` `style_ass_tags={}` `text_padding_y=10`
![{} 10](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/019b05a3-6165-4a6a-9df5-42dd3188b717)
- `scale_playlist_by_window=no` `showamount=auto` `style_ass_tags={\fs15}` `text_padding_y=10`
![{fs15} 10](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/98b77536-f027-40d4-981d-649cfd88059c)
- `scale_playlist_by_window=no`  `showamount=auto` `style_ass_tags={\fs15}` `text_padding_y=30`
![{fs15} 30](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/01fc59a5-822e-407a-bf1b-66bb5f11a6b3)
- `scale_playlist_by_window=no` `showamount=auto` `style_ass_tags={\fs30}` `text_padding_y=10`
![{fs30} 10](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/d4eb68ae-5c8c-46e8-85d2-6f3aa32f45c8)

### Known bugs
1. If options like this, the font size of each line is different from the global `style_ass_tags`, auto calculate is based on `style_ass_tags`'s font size, so it must have a bug, but I think nobody would set this strange configuration, this bug can be ignored
```
style_ass_tags={\fs15}
playlist_header={\fs20}Playlist [%cursor/%plen]
normal_file={\fs16}○ %name
hovered_file={\fs16}● %name
playing_hovered_file={\fs18}▶ %name
...
```
2. **[fixed]** ~~If some long file names occupy more than one line, it will definitely overflow, I have no idea to get the number of filename occupied lines. It's better to use  `showamount=auto`  and `slice_longfilenames=yes` together.~~
3. **[fixed]** ~~`scale_playlist_by_window=no` is required, at present, I don't know how `scale_playlist_by_window=yes` works~~ 