### PR TITLE
support padding on all alignments, fix #87

### DIFF
--- a/playlistmanager.conf
+++ b/playlistmanager.conf
@@ -125,7 +125,7 @@ showamount=-1
 #these styles will be used for the whole playlist
 #the q2 style is recommended since filename wrapping may lead to unexpected rendering
 style_ass_tags={\q2}
-#paddings for top left corner
+#paddings for left right and top bottom, depends on alignment
 text_padding_x=30
 text_padding_y=60
 

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -678,7 +678,7 @@ function draw_playlist()
   -- align from style_ass_tags
   if settings.style_ass_tags ~= nil then
     local an = tonumber(settings.style_ass_tags:match('\\an(%d)'))
-    if an ~= nil then
+    if an ~= nil and alignment_table[an] ~= nil then
       align_x = alignment_table[an]["x"]
       align_y = alignment_table[an]["y"]
     end

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -172,7 +172,7 @@ local settings = {
   --these styles will be used for the whole playlist
   --the q2 style is recommended since filename wrapping may lead to unexpected rendering
   style_ass_tags = "{\\q2}",
-  --paddings from corner
+  --paddings for left right and top bottom, depends on alignment 
   text_padding_x = 30,
   text_padding_y = 60,
   

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -172,7 +172,7 @@ local settings = {
   --these styles will be used for the whole playlist
   --the q2 style is recommended since filename wrapping may lead to unexpected rendering
   style_ass_tags = "{\\q2}",
-  --paddings from top left corner
+  --paddings from corner
   text_padding_x = 30,
   text_padding_y = 60,
   
@@ -242,10 +242,8 @@ if settings.showamount == -1 then
   local h = 720
   
   local playlist_h = h
-  if mp.get_property("osd-align-x") == "left" and mp.get_property("osd-align-y") == "top" then
-    -- both top and bottom with same padding
-    playlist_h = playlist_h - settings.text_padding_y * 2
-  end
+  -- both top and bottom with same padding
+  playlist_h = playlist_h - settings.text_padding_y * 2
   
   -- osd-font-size is based on 720p height
   -- see https://mpv.io/manual/stable/#options-osd-font-size 
@@ -649,7 +647,7 @@ function draw_playlist()
 	
   local _, _, a = mp.get_osd_size()
   local h = 720
-  local w = h * a
+  local w = math.ceil(h * a)
 
   if settings.curtain_opacity ~= nil and settings.curtain_opacity ~= 0 and settings.curtain_opacity <= 1.0 then
   -- curtain dim from https://github.com/christoph-heinrich/mpv-quality-menu/blob/501794bfbef468ee6a61e54fc8821fe5cd72c4ed/quality-menu.lua#L699-L707
@@ -663,10 +661,63 @@ function draw_playlist()
 	
   ass:append(settings.style_ass_tags)
 
-  -- TODO: padding should work even on different osd alignments
-  if mp.get_property("osd-align-x") == "left" and mp.get_property("osd-align-y") == "top" then
-    ass:pos(settings.text_padding_x, settings.text_padding_y)
+  -- align from mpv.conf
+  local align_x = mp.get_property("osd-align-x")
+  local align_y = mp.get_property("osd-align-y")
+  -- align from style_ass_tags
+  if settings.style_ass_tags ~= nil then
+    local an_tag = settings.style_ass_tags:match('\\an%d')
+    if an_tag ~= nil then
+      local an = tonumber(an_tag:match('%d'))
+      if an == 1 then
+        align_x = 'left'
+        align_y = 'bottom'
+      elseif an == 2 then
+        align_x = 'center'
+        align_y = 'bottom'
+      elseif an == 3 then
+        align_x = 'right'
+        align_y = 'bottom'
+      elseif an == 4 then
+        align_x = 'left'
+        align_y = 'center'
+      elseif an == 5 then
+        align_x = 'center'
+        align_y = 'center'
+      elseif an == 6 then
+        align_x = 'right'
+        align_y = 'center'
+      elseif an == 7 then
+        align_x = 'left'
+        align_y = 'top'
+      elseif an == 8 then
+        align_x = 'center'
+        align_y = 'top'
+      elseif an == 9 then
+        align_x = 'right'
+        align_y = 'top'
+      end
+    end
   end
+  -- range of x [0, w-1]
+  local pos_x
+  if align_x == 'left' then
+    pos_x = settings.text_padding_x
+  elseif align_x == 'right' then
+    pos_x = w - 1 - settings.text_padding_x
+  else
+    pos_x = math.floor((w - 1) / 2)
+  end
+  -- range of y [0, h-1]
+  local pos_y
+  if align_y == 'top' then
+    pos_y = settings.text_padding_y
+  elseif align_y == 'bottom' then
+    pos_y = h - 1 - settings.text_padding_y
+  else
+    pos_y = math.floor((h - 1) / 2)
+  end
+  ass:pos(pos_x, pos_y)
 
   if settings.playlist_header ~= "" then
     ass:append(parse_header(settings.playlist_header).."\\N")

--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -225,6 +225,17 @@ local utils = require("mp.utils")
 local msg = require("mp.msg")
 local assdraw = require("mp.assdraw")
 
+local alignment_table = {
+    [1] = { ["x"] = "left",   ["y"] = "bottom" },
+    [2] = { ["x"] = "center", ["y"] = "bottom" },
+    [3] = { ["x"] = "right",  ["y"] = "bottom" },
+    [4] = { ["x"] = "left",   ["y"] = "center" },
+    [5] = { ["x"] = "center", ["y"] = "center" },
+    [6] = { ["x"] = "right",  ["y"] = "center" },
+    [7] = { ["x"] = "left",   ["y"] = "top" },
+    [8] = { ["x"] = "center", ["y"] = "top" },
+    [9] = { ["x"] = "right",  ["y"] = "top" },
+}
 
 --check os
 if settings.system=="auto" then
@@ -666,37 +677,10 @@ function draw_playlist()
   local align_y = mp.get_property("osd-align-y")
   -- align from style_ass_tags
   if settings.style_ass_tags ~= nil then
-    local an_tag = settings.style_ass_tags:match('\\an%d')
-    if an_tag ~= nil then
-      local an = tonumber(an_tag:match('%d'))
-      if an == 1 then
-        align_x = 'left'
-        align_y = 'bottom'
-      elseif an == 2 then
-        align_x = 'center'
-        align_y = 'bottom'
-      elseif an == 3 then
-        align_x = 'right'
-        align_y = 'bottom'
-      elseif an == 4 then
-        align_x = 'left'
-        align_y = 'center'
-      elseif an == 5 then
-        align_x = 'center'
-        align_y = 'center'
-      elseif an == 6 then
-        align_x = 'right'
-        align_y = 'center'
-      elseif an == 7 then
-        align_x = 'left'
-        align_y = 'top'
-      elseif an == 8 then
-        align_x = 'center'
-        align_y = 'top'
-      elseif an == 9 then
-        align_x = 'right'
-        align_y = 'top'
-      end
+    local an = tonumber(settings.style_ass_tags:match('\\an(%d)'))
+    if an ~= nil then
+      align_x = alignment_table[an]["x"]
+      align_y = alignment_table[an]["y"]
     end
   end
   -- range of x [0, w-1]


### PR DESCRIPTION
`style_ass_tags={\q2\fs50}` `text_padding_x=100` `text_padding_y=100`
1. left-bottom
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/bbbfe9d1-4f25-4a6c-80d5-04184172eeaf)
3. center-bottom
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/09f7bc3e-a00f-4a11-b6f0-78d9f9b9b5cf)
4. right-bottom
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/cf12b56d-58b2-429d-9db4-e0ee234d5c6e)
5. left-center
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/5a57a49b-f508-4275-a9aa-e3bd0d6b1010)
6. center-center
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/d414c279-2e80-4054-b617-67fa37cc4616)
7. right-center
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/6720157d-68ee-4996-b340-b121384ad7b4)
8. left-top
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/654fe052-f0f0-477c-8cc8-5b5c7c8e91df)
9. center-top
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/99dea53f-0f9d-4ddc-89b8-08bed5357f91)
10. right-top
![image](https://github.com/jonniek/mpv-playlistmanager/assets/45035465/27a2bc52-15b1-4b10-b907-90367c05652d)

> For center alignments I don't think padding should apply since direction is not clear.

That's true.

I think ASS tag `\an7` shoud add to the recommended style, override the default osd alignment in `mpv.conf`, forced left-top, other alignments feels a little jarring, especially x center or right, long filenames are display badly, the symbols on the left are out of window.
