### PR TITLE
Resume playing from pause when file selected

### DIFF
--- a/playlistmanager.lua
+++ b/playlistmanager.lua
@@ -1076,6 +1076,10 @@ function playfile()
   if cursor ~= pos or is_idle then
     write_watch_later()
     mp.set_property("playlist-pos", cursor)
+    if (mp.get_property_native('pause')) then     -- TK resume playback on playlist file selection
+      mp.set_property_native("pause",false)
+      msg.info("Pause cycled")
+    end
   else
     if cursor~=plen-1 then
       cursor = cursor + 1


### PR DESCRIPTION
I found a little anoyance in my setup - when player is paused and new item is selected from playlist, it must be manually unpaused. So I made this little modification which reverts playing when playlist item is selected. There's no additional configuration around it, maybe you find it usefull for integration in your code.